### PR TITLE
use arrow func for episodeParseCron()

### DIFF
--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -20,13 +20,13 @@ export class Scheduler {
 	
 	public episodeParseCron = new CronJob(
 		'*/15 * * * * *', // cronTime
-		this.evaluteParseConditions, // onTick
+		() => this.evaluateParseConditions(), // onTick - use arrow function to preserve 'this' context
 		null, // onComplete
 		true, // start
 		'America/Chicago' // timeZone
 	);
 
-	private evaluteParseConditions():void {
+	private evaluateParseConditions(): void {
 		// check dir watcher
 		console.log("checking for changes");
 		if (this.episodeWatcher.changesSinceXmlGen) {


### PR DESCRIPTION
When the new CronJob() is made, it loses `this`
context. Use an arrow function to preserve `this`
context from the Scheduler class.